### PR TITLE
Add arm64 iOS simulator target.

### DIFF
--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
     jvm()
     iosX64()
     iosArm64()
+    iosSimulatorArm64()
     macosX64()
     macosArm64()
     js(IR) {
@@ -41,6 +42,9 @@ kotlin {
             dependsOn(appleMain)
         }
         val iosArm64Main by getting {
+            dependsOn(appleMain)
+        }
+        val iosSimulatorArm64Main by getting {
             dependsOn(appleMain)
         }
         val macosX64Main by getting {

--- a/app/ios/build.gradle.kts
+++ b/app/ios/build.gradle.kts
@@ -1,10 +1,12 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
 }
 
 kotlin {
-    ios("uikit") {
+    fun KotlinNativeTarget.configureIosTarget() {
         binaries {
             executable {
                 entryPoint = "com.seiko.imageloader.demo.main"
@@ -18,11 +20,21 @@ kotlin {
             }
         }
     }
+    ios("uikit") {
+        configureIosTarget()
+    }
+    iosSimulatorArm64("uikitSimulatorArm64") {
+        configureIosTarget()
+    }
+
     sourceSets {
         val uikitMain by getting {
             dependencies {
                 implementation(projects.app.common)
             }
+        }
+        val uikitSimulatorArm64Main by getting {
+            dependsOn(uikitMain)
         }
     }
 }

--- a/image-loader/build.gradle.kts
+++ b/image-loader/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
     }
     jvm("desktop")
     ios()
+    iosSimulatorArm64()
     macosX64()
     macosArm64()
     js(IR) {
@@ -64,6 +65,9 @@ kotlin {
         }
         val iosMain by getting {
             dependsOn(darwinMain)
+        }
+        val iosSimulatorArm64Main by getting {
+            dependsOn(iosMain)
         }
         val macosX64Main by getting {
             dependsOn(darwinMain)


### PR DESCRIPTION
Hi, this should add arm64 simulator target for iOS, so that people can run iOS apps on the arm64 simulator on M1/M2 Macs. I couldn't test it unfortunately as my machine fails to run iOS simulator from the IntelliJ IDEA (only works with Xcode and I couldn't get it working), but it should just work.