### PR TITLE
Placeholder and Error painter

### DIFF
--- a/image-loader/src/commonMain/kotlin/com/seiko/imageloader/model/ImageRequest.kt
+++ b/image-loader/src/commonMain/kotlin/com/seiko/imageloader/model/ImageRequest.kt
@@ -1,6 +1,8 @@
 package com.seiko.imageloader.model
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.painter.Painter
 import com.seiko.imageloader.component.ComponentRegistry
 import com.seiko.imageloader.component.ComponentRegistryBuilder
 import com.seiko.imageloader.intercept.Interceptor
@@ -16,6 +18,8 @@ class ImageRequest internal constructor(
     internal val components: ComponentRegistry?,
     internal val interceptors: List<Interceptor>?,
     internal val eventListener: List<ImageRequestEventListener>?,
+    val placeholderPainter: (@Composable () -> Painter)?,
+    val errorPainter: (@Composable () -> Painter)?,
 ) {
     internal fun call(event: ImageRequestEvent) {
         eventListener?.forEach { it.invoke(event) }
@@ -33,6 +37,8 @@ class ImageRequestBuilder {
     private var componentBuilder: ComponentRegistryBuilder?
     private var interceptors: MutableList<Interceptor>?
     private var eventListener: MutableList<ImageRequestEventListener>?
+    private var placeholderPainter: (@Composable () -> Painter)?
+    private var errorPainter: (@Composable () -> Painter)?
 
     internal constructor() {
         data = null
@@ -41,6 +47,8 @@ class ImageRequestBuilder {
         componentBuilder = null
         interceptors = null
         eventListener = null
+        placeholderPainter = null
+        errorPainter = null
     }
 
     internal constructor(request: ImageRequest) {
@@ -50,6 +58,8 @@ class ImageRequestBuilder {
         componentBuilder = request.components?.newBuilder()
         interceptors = request.interceptors?.toMutableList()
         eventListener = request.eventListener?.toMutableList()
+        placeholderPainter = request.placeholderPainter
+        errorPainter = request.errorPainter
     }
 
     fun data(data: Any?) {
@@ -92,6 +102,14 @@ class ImageRequestBuilder {
             ?: extraData(builder)
     }
 
+    fun placeholderPainter(loader: @Composable () -> Painter) {
+        placeholderPainter = loader
+    }
+
+    fun errorPainter(loader: @Composable () -> Painter) {
+        errorPainter = loader
+    }
+
     fun build() = ImageRequest(
         data = data ?: NullRequestData,
         optionsBuilders = optionsBuilders,
@@ -99,6 +117,8 @@ class ImageRequestBuilder {
         interceptors = interceptors,
         extra = extraData ?: EmptyExtraData,
         eventListener = eventListener,
+        placeholderPainter = placeholderPainter,
+        errorPainter = errorPainter
     )
 }
 

--- a/image-loader/src/commonMain/kotlin/com/seiko/imageloader/model/ImageRequest.kt
+++ b/image-loader/src/commonMain/kotlin/com/seiko/imageloader/model/ImageRequest.kt
@@ -118,7 +118,7 @@ class ImageRequestBuilder {
         extra = extraData ?: EmptyExtraData,
         eventListener = eventListener,
         placeholderPainter = placeholderPainter,
-        errorPainter = errorPainter
+        errorPainter = errorPainter,
     )
 }
 

--- a/image-loader/src/commonMain/singleton/com/seiko/imageloader/AsyncImagePainter.kt
+++ b/image-loader/src/commonMain/singleton/com/seiko/imageloader/AsyncImagePainter.kt
@@ -76,6 +76,81 @@ fun rememberAsyncImagePainter(
     return painter
 }
 
+@Composable
+fun rememberImagePainter(
+    url: String,
+    imageLoader: ImageLoader = LocalImageLoader.current,
+    contentScale: ContentScale = ContentScale.Fit,
+    filterQuality: FilterQuality = DefaultFilterQuality,
+    placeholderPainter: (@Composable () -> Painter)? = null,
+    errorPainter: (@Composable () -> Painter)? = null,
+): Painter {
+    val request = remember(url) {
+        ImageRequest {
+            data(url)
+            if (placeholderPainter != null) {
+                placeholderPainter { placeholderPainter() }
+            }
+            if (errorPainter != null) {
+                errorPainter { errorPainter() }
+            }
+        }
+    }
+    return rememberImagePainter(
+        request = request,
+        imageLoader = imageLoader,
+        contentScale = contentScale,
+        filterQuality = filterQuality
+    )
+}
+
+@Composable
+fun rememberImagePainter(
+    resId: Int,
+    imageLoader: ImageLoader = LocalImageLoader.current,
+    contentScale: ContentScale = ContentScale.Fit,
+    filterQuality: FilterQuality = DefaultFilterQuality,
+    placeholderPainter: (@Composable () -> Painter)? = null,
+    errorPainter: (@Composable () -> Painter)? = null,
+): Painter {
+    val request = remember(resId) {
+        ImageRequest {
+            data(resId)
+            if (placeholderPainter != null) {
+                placeholderPainter { placeholderPainter() }
+            }
+            if (errorPainter != null) {
+                errorPainter { errorPainter() }
+            }
+        }
+    }
+    return rememberImagePainter(
+        request = request,
+        imageLoader = imageLoader,
+        contentScale = contentScale,
+        filterQuality = filterQuality
+    )
+}
+
+@Composable
+fun rememberImagePainter(
+    request: ImageRequest,
+    imageLoader: ImageLoader = LocalImageLoader.current,
+    contentScale: ContentScale = ContentScale.Fit,
+    filterQuality: FilterQuality = DefaultFilterQuality
+): Painter {
+    val painter = remember { AsyncImagePainter(request, imageLoader) }
+    painter.imageLoader = imageLoader
+    painter.request = request
+    painter.contentScale = contentScale
+    painter.filterQuality = filterQuality
+    return when (painter.requestState) {
+        is ImageRequestState.Loading -> request.placeholderPainter?.invoke() ?: painter
+        is ImageRequestState.Failure -> request.errorPainter?.invoke() ?: painter
+        else -> painter
+    }
+}
+
 @Stable
 class AsyncImagePainter(
     request: ImageRequest,

--- a/image-loader/src/commonMain/singleton/com/seiko/imageloader/AsyncImagePainter.kt
+++ b/image-loader/src/commonMain/singleton/com/seiko/imageloader/AsyncImagePainter.kt
@@ -100,7 +100,7 @@ fun rememberImagePainter(
         request = request,
         imageLoader = imageLoader,
         contentScale = contentScale,
-        filterQuality = filterQuality
+        filterQuality = filterQuality,
     )
 }
 
@@ -128,7 +128,7 @@ fun rememberImagePainter(
         request = request,
         imageLoader = imageLoader,
         contentScale = contentScale,
-        filterQuality = filterQuality
+        filterQuality = filterQuality,
     )
 }
 
@@ -137,7 +137,7 @@ fun rememberImagePainter(
     request: ImageRequest,
     imageLoader: ImageLoader = LocalImageLoader.current,
     contentScale: ContentScale = ContentScale.Fit,
-    filterQuality: FilterQuality = DefaultFilterQuality
+    filterQuality: FilterQuality = DefaultFilterQuality,
 ): Painter {
     val painter = remember { AsyncImagePainter(request, imageLoader) }
     painter.imageLoader = imageLoader


### PR DESCRIPTION
This adds support for providing a placeholder and error painter.
I added new methods for this.

I think this needs some improvements, e.g. we can specify these in `rememberAsyncImagePainter` using the `ImageRequest` Builder, however they will be never considered in this method.

I thought of handling it in the `AsyncImagePainter`, but couldn't really think of an implementation.
We need the error and placeholder loaders as composable as many libraries etc provide painter as such, e.g. moko-resource and don't wanna store the painters in memory as long as they are not needed or cause unnecessary recompositions.