### PR TITLE
Pass context in setupDefaultComponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Compose ImageLoader
+ # Compose ImageLoader
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.qdsfdhvh/image-loader/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.qdsfdhvh/image-loader)
 
 Compose Image library for Kotlin Multiplatform.
@@ -100,7 +100,7 @@ fun generateImageLoader(): ImageLoader {
             androidContext(applicationContext)
         }
         components {
-            setupDefaultComponents()
+            setupDefaultComponents(context)
         }
         interceptor {
             // cache 25% memory bitmap


### PR DESCRIPTION
### Android Setup Update
Update the Android setup section to reflect a required change in the generateImageLoader method. The setupDefaultComponents function must now be called with a context parameter.

Without passing the context, images will not load properly on Android.

#### Before:

`setupDefaultComponents()
`

#### After: 

`setupDefaultComponents(context)
`